### PR TITLE
Refactor Alerts and use Await

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,26 +1,13 @@
-import { name, version, description } from './package.json'
+import {
+  name,
+  version,
+  description,
+  author,
+  bugs
+} from './package.json'
+
 import restify from 'restify'
-import RedisSMQ from 'rsmq'
-
-const rsmq = new RedisSMQ({
-  host: 'redis',
-  port: 6379,
-  ns: 'phonebox'
-})
-
-function alertHandler (req, res, next) {
-  rsmq.sendMessage({
-    qname: 'alerts',
-    message: req.body
-  }, (err, id) => {
-    if (err) return next(err)
-
-    if (id) {
-      return res.send(id)
-    }
-    return next()
-  })
-}
+import { alerts } from './handlers'
 
 const server = restify.createServer()
 server.use(restify.bodyParser())
@@ -29,11 +16,13 @@ server.get('/', (req, res) => {
   res.json({
     name,
     version,
-    description
+    description,
+    author,
+    bugs
   })
 })
 
-server.post('/alerts', alertHandler)
+server.post('/alerts', alerts.post)
 
 server.listen(8080, () => {
   console.log('%s listening at %s', server.name, server.url)

--- a/src/api/handlers/alerts.js
+++ b/src/api/handlers/alerts.js
@@ -1,0 +1,22 @@
+import Promise from 'bluebird'
+import RedisSMQ from 'rsmq'
+
+const rsmq = Promise.promisifyAll(new RedisSMQ({
+  host: 'redis',
+  port: 6379,
+  ns: 'phonebox'
+}))
+
+export default {
+  post: async (req, res, next) => {
+    try {
+      const id = await rsmq.sendMessageAsync({
+        qname: 'alerts',
+        message: JSON.stringify(req.body)
+      })
+      res.json({ id })
+    } catch (err) {
+      next(err)
+    }
+  }
+}

--- a/src/api/handlers/index.js
+++ b/src/api/handlers/index.js
@@ -1,0 +1,1 @@
+export { default as alerts } from './alerts'

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -25,6 +25,7 @@
   "author": "Craftship Limited <hello@craftship.io>",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.4.0",
     "restify": "^4.0.4",
     "rsmq": "^0.7.0"
   },


### PR DESCRIPTION
Moves alerts handler for route into its own file and implements async await for a cleaner implementation.  Requires bluebird to turn rsmq functions to be async.
