### PR TITLE
Basic Twilio Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env*

--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -16,3 +16,8 @@ workers:
     - redis
   volumes:
     - /usr/src/app
+  environment:
+    - TWILIO_SID
+    - TWILIO_TOKEN
+    - TWILIO_FROM_NUMBER
+    - TWILIO_TO_NUMBER

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     build: ./src/workers
     volumes:
      - ./src/workers:/usr/src/app/
+    env_file: ./src/workers/.env-workers
     links:
       - redis
     depends_on:

--- a/src/workers/alerts/base.js
+++ b/src/workers/alerts/base.js
@@ -1,0 +1,42 @@
+import RSMQWorker from 'rsmq-worker'
+import twilio from 'twilio'
+
+const client = new twilio.RestClient(
+  process.env.TWILIO_SID,
+  process.env.TWILIO_TOKEN
+)
+
+export class BaseAlertWorker extends RSMQWorker {
+  constructor (rsmq) {
+    super('alerts', { rsmq })
+
+    this.on('message', (message, next) => {
+      this.process(message, next)
+    })
+
+    this.on('error', (err, msg) => {
+      console.log('ERROR', err, msg.id)
+    })
+
+    this.on('exceeded', msg => {
+      console.log('EXCEEDED', msg.id)
+    })
+
+    this.on('timeout', msg => {
+      console.log('TIMEOUT', msg.id, msg.rc)
+    })
+  }
+
+  text (message, next) {
+    client.messages.create({
+      body: message,
+      to: process.env.TWILIO_TO_NUMBER,
+      from: process.env.TWILIO_FROM_NUMBER
+    }, (err, response) => {
+      if (err) return next(err)
+      next()
+    })
+  }
+}
+
+export default BaseAlertWorker

--- a/src/workers/alerts/index.js
+++ b/src/workers/alerts/index.js
@@ -1,4 +1,1 @@
-export default function (rsmq, box) {
-  require(`./${box}`).default(rsmq)
-}
-
+export { default as NewRelicAlert } from './newrelic'

--- a/src/workers/alerts/newrelic.js
+++ b/src/workers/alerts/newrelic.js
@@ -1,25 +1,10 @@
-import RSMQWorker from 'rsmq-worker'
+import BaseAlertWorker from './base'
 
-export default function (rsmq) {
-  const worker = new RSMQWorker('alerts', { rsmq })
-
-  worker.on('message', (message, next) => {
-    console.log(JSON.parse(message))
-    next()
-  })
-
-  worker.on('error', (err, msg) => {
-    console.log('ERROR', err, msg.id)
-  })
-
-  worker.on('exceeded', msg => {
-    console.log('EXCEEDED', msg.id)
-  })
-
-  worker.on('timeout', msg => {
-    console.log('TIMEOUT', msg.id, msg.rc)
-  })
-
-  worker.start()
+export class NewRelicAlert extends BaseAlertWorker {
+  process (message, next) {
+    this.text(message, next)
+  }
 }
+
+export default NewRelicAlert
 

--- a/src/workers/package.json
+++ b/src/workers/package.json
@@ -26,7 +26,8 @@
   "license": "MIT",
   "dependencies": {
     "rsmq": "^0.7.0",
-    "rsmq-worker": "^0.4.2"
+    "rsmq-worker": "^0.4.2",
+    "twilio": "^2.9.1"
   },
   "devDependencies": {
     "babel-core": "^6.9.0",

--- a/src/workers/workers.js
+++ b/src/workers/workers.js
@@ -1,5 +1,5 @@
 import RedisSMQ from 'rsmq'
-import createAlertWorker from './alerts'
+import { NewRelicAlert } from './alerts'
 
 const rsmq = new RedisSMQ({
   host: 'redis',
@@ -20,6 +20,7 @@ function createQueue (name) {
   await createQueue('alerts')
   await createQueue('calls')
 
-  createAlertWorker(rsmq, 'newrelic')
+  const newRelicAlert = new NewRelicAlert(rsmq)
+  newRelicAlert.start()
 })()
 


### PR DESCRIPTION
- Creates a base worker to allow simple API for additional alert sources such as things like ZenDesk and beyond.
- Ability to currently set single person on support to send a text message to test Twilio
- Amend configs to support required ENV variables:

```
TWILIO_SID
TWILIO_TOKEN
TWILIO_FROM_NUMBER
TWILIO_TO_NUMBER
```
