### PR TITLE
Specs Setup / Initial Text Message Spec

### DIFF
--- a/src/workers/egress/text_message/index.js
+++ b/src/workers/egress/text_message/index.js
@@ -2,14 +2,14 @@ import BaseWorker from '../../base'
 import twilio from 'twilio'
 import path from 'path'
 
-const client = new twilio.RestClient(
-  process.env.TWILIO_SID,
-  process.env.TWILIO_TOKEN
-)
-
 export class TextMessage extends BaseWorker {
   constructor (rsmq) {
     super('text_message', rsmq)
+
+    this.client = new twilio.RestClient(
+      process.env.TWILIO_SID,
+      process.env.TWILIO_TOKEN
+    )
   }
 
   body (message) {
@@ -21,12 +21,12 @@ export class TextMessage extends BaseWorker {
 
   async process (message, next) {
     try {
-      await client.sendMessage({
+      await this.client.sendMessage({
         body: this.body(message),
         to: process.env.TWILIO_TO_NUMBER,
         from: process.env.TWILIO_FROM_NUMBER
       })
-      next()
+      next(null)
     } catch (err) {
       next(err)
     }

--- a/src/workers/egress/text_message/index.js
+++ b/src/workers/egress/text_message/index.js
@@ -12,18 +12,24 @@ export class TextMessage extends BaseWorker {
     super('text_message', rsmq)
   }
 
-  process (message, next) {
-    client.messages.create({
-      body: super.render(
-        path.join(__dirname, '../templates', 'plain_text.ejs'),
-        message
-      ),
-      to: process.env.TWILIO_TO_NUMBER,
-      from: process.env.TWILIO_FROM_NUMBER
-    }, (err, response) => {
-      if (err) return next(err)
+  body (message) {
+    return this.render(
+      path.join(__dirname, '../templates', 'plain_text.ejs'),
+      message
+    )
+  }
+
+  async process (message, next) {
+    try {
+      await client.sendMessage({
+        body: this.body(message),
+        to: process.env.TWILIO_TO_NUMBER,
+        from: process.env.TWILIO_FROM_NUMBER
+      })
       next()
-    })
+    } catch (err) {
+      next(err)
+    }
   }
 }
 

--- a/src/workers/egress/text_message/spec/index.spec.js
+++ b/src/workers/egress/text_message/spec/index.spec.js
@@ -1,0 +1,82 @@
+import path from 'path'
+import twilio from './mocks/twilio.js'
+import message from './message.json'
+
+function textMessage (scenario) {
+  const TextMessage = injectr('../../egress/text_message/index.js', {
+    'BaseWorker': sinon.stub(),
+    'twilio': twilio[scenario]
+  }, {
+    process,
+    path,
+    __dirname: path.join(__dirname, '../')
+  }).default
+
+  return new TextMessage(sinon.stub())
+}
+
+describe('Text Message', () => {
+  let fixture
+  let next
+
+  beforeEach(() => {
+    fixture = JSON.stringify(message)
+    next = sinon.stub()
+  })
+
+  describe('#body', () => {
+    it('should render in plain text', () => {
+      const subject = textMessage('success')
+      const body = subject.body(fixture)
+
+      assert.equal(body, 'account foo\nbar severity\nfoo bar details\n')
+    })
+  })
+
+  describe('#process', () => {
+    describe('with error', () => {
+      let subject
+
+      beforeEach(() => {
+        subject = textMessage('error')
+        sinon.spy(subject.client, 'sendMessage')
+      })
+
+      it('should pass error to base worker', async (done) => {
+        await subject.process(fixture, next)
+        assert.isFalse(next.calledWith(null))
+        done()
+      })
+
+      afterEach(() => {
+        sinon.restore(subject.client)
+      })
+    })
+
+    describe('without error', () => {
+      let subject
+
+      beforeEach(() => {
+        subject = textMessage('success')
+        sinon.spy(subject.client, 'sendMessage')
+      })
+
+      it('should send a text message', async (done) => {
+        await subject.process(fixture, next)
+        assert.isTrue(subject.client.sendMessage.called)
+        done()
+      })
+
+      it('should delete message from queue', async (done) => {
+        await subject.process(fixture, next)
+        assert.isTrue(next.calledWith(null))
+        done()
+      })
+
+      afterEach(() => {
+        sinon.restore(subject.client)
+      })
+    })
+  })
+})
+

--- a/src/workers/egress/text_message/spec/message.json
+++ b/src/workers/egress/text_message/spec/message.json
@@ -1,0 +1,5 @@
+{
+  "title": "account foo",
+  "severity": "bar severity",
+  "details": "foo bar details"
+}

--- a/src/workers/egress/text_message/spec/mocks/fixtures/error.json
+++ b/src/workers/egress/text_message/spec/mocks/fixtures/error.json
@@ -1,0 +1,4 @@
+{
+  "status": 404,
+  "message": "The requested resource was not found"
+}

--- a/src/workers/egress/text_message/spec/mocks/fixtures/success.json
+++ b/src/workers/egress/text_message/spec/mocks/fixtures/success.json
@@ -1,0 +1,38 @@
+{
+  "sid": "123456789",
+  "date_created": "Sun, 22 May 2016 11:13:00 +0000",
+  "date_updated": "Sun, 22 May 2016 11:13:00 +0000",
+  "date_sent": null,
+  "account_sid": "123456789",
+  "to": "+440000000000",
+  "from": "+440000000000",
+  "messaging_service_sid": null,
+  "body": "Sent from your Twilio trial account - My Tesco\nINFO\nNew Relic Alert - Channel Test",
+  "status": "queued",
+  "num_segments": "1",
+  "num_media": "0",
+  "direction": "outbound-api",
+  "api_version": "2010-04-01",
+  "price": null,
+  "price_unit": "USD",
+  "error_code": null,
+  "error_message": null,
+  "uri": "/2010-04-01/Accounts/123/Messages/123.json",
+  "subresource_uris": {
+    "media": "/2010-04-01/Accounts/123/Messages/123/Media.json"
+  },
+  "dateCreated": "2016-05-22T11:13:00.000Z",
+  "dateUpdated": "2016-05-22T11:13:00.000Z",
+  "dateSent": null,
+  "accountSid": "123456789",
+  "messagingServiceSid": null,
+  "numSegments": "1",
+  "numMedia": "0",
+  "apiVersion": "2010-04-01",
+  "priceUnit": "USD",
+  "errorCode": null,
+  "errorMessage": null,
+  "subresourceUris": {
+    "media": "/2010-04-01/Accounts/123/Messages/123/Media.json"
+  }
+}

--- a/src/workers/egress/text_message/spec/mocks/twilio.js
+++ b/src/workers/egress/text_message/spec/mocks/twilio.js
@@ -1,0 +1,19 @@
+import success from './fixtures/success.json'
+import error from './fixtures/error.json'
+
+export default {
+  success: {
+    RestClient: class {
+      sendMessage () {
+        return Promise.resolve(success)
+      }
+    }
+  },
+  error: {
+    RestClient: class {
+      sendMessage () {
+        return Promise.reject(error)
+      }
+    }
+  }
+}

--- a/src/workers/package.json
+++ b/src/workers/package.json
@@ -52,7 +52,6 @@
       "after",
       "afterEach",
       "it",
-      "expect",
       "assert",
       "sinon"
     ],

--- a/src/workers/package.json
+++ b/src/workers/package.json
@@ -18,7 +18,7 @@
     "email": "bugs@craftship.io"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "$(npm bin)/mocha ./egress/**/*.spec.js",
     "lint": "$(npm bin)/standard",
     "start": "node ."
   },
@@ -37,9 +37,25 @@
     "babel-plugin-syntax-async-functions": "^6.8.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
+    "chai": "^3.5.0",
+    "injectr": "^0.5.1",
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.4",
     "standard": "^7.1.0"
   },
   "standard": {
+    "globals": [
+      "describe",
+      "context",
+      "before",
+      "beforeEach",
+      "after",
+      "afterEach",
+      "it",
+      "expect",
+      "assert",
+      "sinon"
+    ],
     "parser": "babel-eslint"
   }
 }

--- a/src/workers/test/helpers/globals.js
+++ b/src/workers/test/helpers/globals.js
@@ -1,0 +1,7 @@
+import injectr from 'injectr'
+import sinon from 'sinon'
+import chai from 'chai'
+
+global.assert = chai.assert
+global.sinon = sinon
+global.injectr = injectr

--- a/src/workers/test/helpers/injectr.js
+++ b/src/workers/test/helpers/injectr.js
@@ -1,0 +1,6 @@
+import injectr from 'injectr'
+
+injectr.onload = (filename, content) =>
+  require('babel-core').transform(content, {
+    filename
+  }).code

--- a/src/workers/test/mocha.opts
+++ b/src/workers/test/mocha.opts
@@ -1,0 +1,3 @@
+--require test/helpers/injectr
+--require test/helpers/globals
+--compilers js:babel-register


### PR DESCRIPTION
- Adds injectr, mocha, sinon for testing
- Configures globals for specs to make writing them cleaner (thanks @jameshopkins)
- Configure globals for standardjs so we don't get errors for things like `describe` and `it`
